### PR TITLE
Fix: scrollToIndex out of range when autoplay set to true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,14 +56,16 @@ export const ImageSlider = ({
 
     useEffect(() => {
         if(autoPlay) {
-            startAutoPlay()
+            if (data.length > 0)
+                startAutoPlay()
         }
     }, []);
 
     useEffect(() => {
         if(!imageViewer) {
             if(autoPlay) {
-                startAutoPlay()
+                if (data.length > 0)
+                    startAutoPlay()
             }
         }
     }, [currentIndex, imageViewer]);


### PR DESCRIPTION
Fix: Invariant Violation: scrollToIndex out of range: item length 0 but minimum is 1 when set autoplay to true and give empty array.